### PR TITLE
Bump mock web3 provider

### DIFF
--- a/basic-dapp/cypress/integration/injected_spec.js
+++ b/basic-dapp/cypress/integration/injected_spec.js
@@ -1,4 +1,4 @@
-import currentProvider from 'jesse-mock-web3-provider'
+import currentProvider from '@rsksmart/mock-web3-provider'
 
 describe('basic app e2e testing', () => {
   const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D';

--- a/basic-dapp/package.json
+++ b/basic-dapp/package.json
@@ -44,6 +44,6 @@
     "cypress": "^6.4.0",
     "enzyme": "^3.11.0",
     "eslint-plugin-cypress": "^2.11.2",
-    "jesse-mock-web3-provider": "^0.0.1"
+    "@rsksmart/mock-web3-provider": "^0.0.1"
   }
 }

--- a/basic-dapp/yarn.lock
+++ b/basic-dapp/yarn.lock
@@ -1664,6 +1664,13 @@
     did-jwt "^4.6.2"
     eth-sig-util "^3.0.0"
 
+"@rsksmart/mock-web3-provider@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@rsksmart/mock-web3-provider/-/mock-web3-provider-0.0.1.tgz#00863c7714d24cdbc8ca3cebdd7f1c4f67e8e49e"
+  integrity sha512-g3LELBA1rTzemuWKkvFswHrO8AspM9K0xg/sPJXmS2da67MfnG0WRhzx5BQf5Vl1H3oBXZrpICBGPtz5WsNdhA==
+  dependencies:
+    eth-sig-util "^3.0.1"
+
 "@rsksmart/rlogin@^1.0.0-beta.1":
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/@rsksmart/rlogin/-/rlogin-1.0.0-beta.1.tgz#49ce76bdd1124be3be94472f4f47950d5fbbdb2b"
@@ -7899,13 +7906,6 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-jesse-mock-web3-provider@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/jesse-mock-web3-provider/-/jesse-mock-web3-provider-0.0.1.tgz#06f2abbb4a32999ef844038cead6ca63f1371b66"
-  integrity sha512-xnJZcoZAI2YNf8APa/qMdp3X49/M9T11OAUgcRNJWHAQChokw76JiqP8ezF/JxtjMvEpmtSMtLtMDOvvHiOqXA==
-  dependencies:
-    eth-sig-util "^3.0.1"
 
 jest-changed-files@^26.6.2:
   version "26.6.2"

--- a/permissioned-app/frontend-app/cypress/integration/permissioned.spec.js
+++ b/permissioned-app/frontend-app/cypress/integration/permissioned.spec.js
@@ -1,4 +1,4 @@
-import currentProvider from 'jesse-mock-web3-provider'
+import currentProvider from '@rsksmart/mock-web3-provider'
 
 describe('permissioned e2e testing', () => {
   const address = '0xB98bD7C7f656290071E52D1aA617D9cB4467Fd6D';

--- a/permissioned-app/frontend-app/package.json
+++ b/permissioned-app/frontend-app/package.json
@@ -43,6 +43,6 @@
   "devDependencies": {
     "cypress": "^6.5.0",
     "eslint-plugin-cypress": "^2.11.2",
-    "jesse-mock-web3-provider": "^0.0.2"
+    "@rsksmart/mock-web3-provider": "^0.0.1"
   }
 }

--- a/permissioned-app/frontend-app/yarn.lock
+++ b/permissioned-app/frontend-app/yarn.lock
@@ -1664,6 +1664,13 @@
     did-jwt "^4.6.2"
     eth-sig-util "^3.0.0"
 
+"@rsksmart/mock-web3-provider@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@rsksmart/mock-web3-provider/-/mock-web3-provider-0.0.1.tgz#00863c7714d24cdbc8ca3cebdd7f1c4f67e8e49e"
+  integrity sha512-g3LELBA1rTzemuWKkvFswHrO8AspM9K0xg/sPJXmS2da67MfnG0WRhzx5BQf5Vl1H3oBXZrpICBGPtz5WsNdhA==
+  dependencies:
+    eth-sig-util "^3.0.1"
+
 "@rsksmart/rlogin@1.0.0-beta.1":
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/@rsksmart/rlogin/-/rlogin-1.0.0-beta.1.tgz#49ce76bdd1124be3be94472f4f47950d5fbbdb2b"
@@ -7687,13 +7694,6 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-jesse-mock-web3-provider@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/jesse-mock-web3-provider/-/jesse-mock-web3-provider-0.0.2.tgz#1944ec7b5bcb90d83062726806d95941877a87bc"
-  integrity sha512-bk0AJ2RXF+0OOpW49rogwC+IgTn4fFj3QXT0Jf9cHOWh1c0VYNyteE1/geJwFOIVS6ohhb8MiGr8s4xsBQIe5Q==
-  dependencies:
-    eth-sig-util "^3.0.1"
 
 jest-changed-files@^26.6.2:
   version "26.6.2"

--- a/permissioned-app/package.json
+++ b/permissioned-app/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "setup": "npm install && yarn --cwd ./frontend-app",
+    "setup": "yarn && yarn --cwd ./frontend-app",
     "start": "concurrently \"node backend/index.js\" \"yarn --cwd ./frontend-app start\"",
     "start:backend": "node backend/index.js",
     "start:frontend": "yarn --cwd ./frontend-app start",


### PR DESCRIPTION
Bumps the mock web3 provider for Cypress testing and updates the permissioned setup function to use yarn. This PR has no effect on the demos, only on testing, and the initial setup of the permissioned app.