### PR TITLE
[devops] Adding backend deployment for permissioned app 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
               --instance-ids "${{ secrets.VM_EC2_ID }}" \
               --region=${{ secrets.MAIN_BASIC_DAPP_AWS_REGION }} \
               --comment "github interaction-rlogin-apps" \
-              --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-marketplace/\",\"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rlogin-back.sh"]}'
+              --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rlogin/\",\"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rlogin-back.sh"]}'
 
       - name: Deploy site to S3
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.MAIN_BASIC_DAPP_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.MAIN_BASIC_DAPP_AWS_REGION }}
 
+      - name: Deploy backend
+        run: |
+          aws ssm send-command \
+              --document-name "AWS-RunRemoteScript" \
+              --instance-ids "${{ secrets.VM_EC2_ID }}" \
+              --region=${{ secrets.MAIN_BASIC_DAPP_AWS_REGION }} \
+              --comment "github interaction-rlogin-apps" \
+              --parameters '{"sourceType":["GitHub"],"sourceInfo":["{\"owner\":\"rootstock\", \"repository\":\"ask-devops\", \"path\": \"rif-marketplace/\",\"tokenInfo\":\"{{ssm-secure:github-token}}\"}"],"commandLine":["deploy-rlogin-back.sh"]}'
+
       - name: Deploy site to S3
         run: |
           cd basic-dapp


### PR DESCRIPTION
* This change on the GH action executes:
```
# Deployment script for rlogin backend
## Deploys permissioned app
cd ~/rlogin-sample-apps/permissioned-app/ || exit
git checkout master && git pull origin master
docker build -t rlogin-sample-permissioned-backend . && docker run -p 3007:3007 -d  --name rlogin-sample-permissioned-backend --init rlogin-sample-permissioned-backend
```
An specific secret should be set up in addition (VM_EC2_ID) , i will pass it via slack   

