### PR TITLE
Fix ethers error

### DIFF
--- a/basic-dapp/src/App.js
+++ b/basic-dapp/src/App.js
@@ -251,14 +251,14 @@ function App() {
   }
 
     // Send transaction
-    const handleSendTransactionEthers = async (to, value) => {
+    const handleSendTransactionEthers = (to, value) => {
       if (rLoginResponse !== null) {
         const provider = new ethers.providers.Web3Provider(rLoginResponse.provider)
         const signer = provider.getSigner()
         setSendResponse('Please check your wallet')
-        const tx = await signer.sendTransaction({ to, value: parseInt(value) })
-        .catch(error => setSendResponse(`[ERROR]: ${error.message}`))
-        setSendResponse(tx.hash)
+        signer.sendTransaction({ to, value: parseInt(value) })
+          .then(response => setSendResponse(response.hash))
+          .catch(error => setSendResponse(`[ERROR]: ${error.message}`))
       }
     }
 

--- a/basic-dapp/src/App.js
+++ b/basic-dapp/src/App.js
@@ -26,12 +26,13 @@ const supportedChains = Object.keys(rpcUrls).map(Number)
 // Create a new rLogin instance with your custom providerOptions outside of the 
 // component.
 const rLogin = new RLogin({
-  cacheProvider: true,
+  cacheProvider: false,
   providerOptions: {
     walletconnect: {
       package: WalletConnectProvider,
       options: {
-        rpc: rpcUrls
+        rpc: rpcUrls,
+        bridge: 'https://walletconnect-bridge.rifos.org/'
       }
     },
     portis: {

--- a/permissioned-app/frontend-app/src/App.js
+++ b/permissioned-app/frontend-app/src/App.js
@@ -30,7 +30,8 @@ const rLogin = new RLogin({
     walletconnect: {
       package: WalletConnectProvider,
       options: {
-        rpc: rpcUrls
+        rpc: rpcUrls,
+        bridge: 'https://walletconnect-bridge.rifos.org/'
       }
     },
     portis: {


### PR DESCRIPTION
If the user rejects the transaction, the tx.hash would still attempt to set (line 261). Instead, let's continue to use then/catch as in the rest of the application. 

Next, update the WC bridge to use our own and set `false` to cachedProvider in the basic dapp since we use this a lot for testing. 